### PR TITLE
Create endpoints for posts and likes filtered by user_id

### DIFF
--- a/backend/cannoli_posts/views.py
+++ b/backend/cannoli_posts/views.py
@@ -13,6 +13,9 @@ class PostList(generics.ListCreateAPIView):
 
     def get_queryset(self):
         qs = super().get_queryset()
+        user_id = self.request.query_params.get('user_id')
+        if user_id is not None:
+            qs = qs.filter(user_id=user_id)
         return qs.annotate(liked_by_user=Exists(Post.liked_by.through.objects.filter(
             post_id=OuterRef('pk'),
             user_id=self.request.user.pk,


### PR DESCRIPTION
## Changes

### Major Changes
Update post listing endpoint to filter by `user_id` if parameter is passed in query. Add GET endpoint for likes that also filters with the same query parameter.

### Bug Fixes / Minor Changes
N/A

## Issues
N/A

## Why
This provides an endpoint where any post made by a given user or posts liked by a given user can be returned as a response.

## How
Added a filter on the query set for the post listing that filters based on the optional `user_id` query parameter. Added a `get()` method to the view for liked posts with the same filter.

## Notes
N/A
