### PR TITLE
Include username in serialized post

### DIFF
--- a/backend/cannoli_posts/serializers.py
+++ b/backend/cannoli_posts/serializers.py
@@ -4,6 +4,7 @@ from .models import Post
 class PostSerializer(serializers.ModelSerializer):
     like_count = serializers.SerializerMethodField(source='count_likes')
     liked_by_user = serializers.BooleanField(required=False)
+    username = serializers.CharField(source='user_id.username', read_only=True)
 
     def count_likes(self, obj):
         return obj.liked_by.count()
@@ -13,7 +14,7 @@ class PostSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Post
-        fields = ['id', 'user_id', 'content', 'like_count', 'liked_by_user', 'create_date']
+        fields = ['id', 'user_id', 'username', 'content', 'like_count', 'liked_by_user', 'create_date']
 
 class LikeSerializer(serializers.Serializer):
     post_id = serializers.IntegerField()


### PR DESCRIPTION
## Changes

### Major Changes
Update serializer for `Post` to include the username

### Bug Fixes / Minor Changes
N/A

## Issues
N/A

## Why
Right now, the posts returned with a GET request of all available posts shows `user_id`, but not `username`. The username should be what's made visible on the client-side to the user (though `user_id` is still useful to have on the frontend for other things like specifying query parameters for other GET requests).

## How
The username is a `serializer.CharField()` with the source set as the username of the user object (in this case, `user_id`) and `read_only=True`.

## Notes
N/A
