### PR TITLE
Update user and profile in backend to support better per-user profile viewing on frontend

### DIFF
--- a/backend/cannoli_auth/serializers.py
+++ b/backend/cannoli_auth/serializers.py
@@ -1,17 +1,24 @@
 from rest_framework import serializers
 from .models import User, UserFollowing
+from cannoli_profiles.models import Profile
 
 class UserSerializer(serializers.ModelSerializer):
     follower_count = serializers.SerializerMethodField(read_only=True)
     following_user = serializers.BooleanField(read_only=True)
     followed_by_user = serializers.BooleanField(read_only=True)
+    profile_id = serializers.SerializerMethodField(read_only=True)
 
     def get_follower_count(self, obj):
         return UserFollowing.objects.filter(following_user_id=obj).count()
 
+    def get_profile_id(self, obj):
+        user_id = obj.id
+        profile_id = Profile.objects.get(id=user_id).id
+        return profile_id
+
     class Meta:
         model = User
-        fields = ['id', 'username', 'date_joined', 'follower_count', 'followed_by_user', 'following_user']
+        fields = ['id', 'username', 'profile_id', 'date_joined', 'follower_count', 'followed_by_user', 'following_user']
 
 class UserFollowSerializer(serializers.ModelSerializer):
     class Meta:

--- a/backend/cannoli_auth/urlsUser.py
+++ b/backend/cannoli_auth/urlsUser.py
@@ -1,8 +1,9 @@
 from django.urls import path, include
-from .views import UserDetail, UserFollow, UserUnfollow
+from .views import UserDetail, UsernameDetail, UserFollow, UserUnfollow
 
 urlpatterns = [
     path('<int:pk>/', UserDetail.as_view()),
     path('<int:pk>/follow/', UserFollow.as_view()),
     path('<int:pk>/unfollow/', UserUnfollow.as_view()),
+    path('<str:username>/', UsernameDetail.as_view()),
 ]

--- a/backend/cannoli_profiles/serializers.py
+++ b/backend/cannoli_profiles/serializers.py
@@ -1,7 +1,13 @@
 from rest_framework import serializers
+from cannoli_auth.models import User
 from cannoli_profiles.models import Profile
 
 class ProfileSerializer(serializers.ModelSerializer):
+    username = serializers.SerializerMethodField(read_only=True)
+
+    def get_username(self, obj):
+        return User.objects.get(pk=obj.user_id.pk).username
+
     class Meta:
         model = Profile
-        fields = ['id', 'user_id', 'about', 'avatar', 'update_date']
+        fields = ['id', 'user_id', 'username', 'about', 'avatar', 'update_date']

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ export const AuthContext = createContext(null);
 
 export default function App() {
   const user: UseQueryResult<UserType, Error> = useQuery({
-    queryKey: ["user"],
+    queryKey: ["user", "current"],
     queryFn: async () => {
       console.log('user useQuery fired')
       const res = await fetchRefresh("http://127.0.0.1:8000/auth/user/", {

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -10,10 +10,10 @@ export default function Nav() {
       <nav>
         <ul>
           <li>
-            <Link to={`login`}>Login</Link>
+            <Link to={'login'}>Login</Link>
           </li>
           <li>
-            <Link to={`register`}>Register</Link>
+            <Link to={'register'}>Register</Link>
           </li>
         </ul>
       </nav>  
@@ -24,7 +24,7 @@ export default function Nav() {
     <nav>
       <ul>
         <li>
-          <Link to={`home`}>Home</Link>
+          <Link to={'home'}>Home</Link>
         </li>
         <li>
           <Link to={`profile/${user.data.username}`}>Profile</Link>

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -27,7 +27,7 @@ export default function Nav() {
           <Link to={`home`}>Home</Link>
         </li>
         <li>
-          <Link to={`profile`}>Profile</Link>
+          <Link to={`profile/${user.data.username}`}>Profile</Link>
         </li>
       </ul>
     </nav>

--- a/frontend/src/routes/Router.tsx
+++ b/frontend/src/routes/Router.tsx
@@ -18,7 +18,7 @@ const Router = createBrowserRouter([
         element: <Home />,
       },
       {
-        path: "profile",
+        path: "profile/:username",
         element: <Profile />,
       },
       {


### PR DESCRIPTION
## Changes

### Major Changes
Updated backend user and profile to share related information that will support fetching data in frontend e.g. getting a `User` by username parameter, including `profile_id` in the user, including `username` in the `Profile`, etc.

Updated frontend `Profile.tsx` component's navigation to pass a parameter for username, then have dependent queries to update the user (being viewed) and the profile to set up the foundation for viewing a user's profile and all their info and activity.

### Bug Fixes / Minor Changes
- Updated some strings in the frontend router to be regular strings instead of template strings
- Change the query key for the overarching user context so that it's more unique compared to the user whose profile the logged in user is currently viewing

## Issues
N/A

## Why
There was no way to look up a user's profile without knowing the profile ID, which would also complicate client-side routing, so updating that on the backend allows for more sane routing as well as creation of links wherever a username shows up (which would take the user to their profile).

## How
See above.

## Notes
N/A
