### PR TITLE
Implement follow/unfollow on user profiles

### DIFF
--- a/frontend/src/routes/ProfileLayout.tsx
+++ b/frontend/src/routes/ProfileLayout.tsx
@@ -1,39 +1,111 @@
-import { useContext } from "react"
-import { Outlet, Navigate, useParams } from "react-router-dom"
-import { useQuery } from "@tanstack/react-query"
-import { fetchRefresh } from "../utils/fetchUtils"
-import { AuthContext } from "../App"
+import { useState, useContext } from "react";
+import { Outlet, useParams } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { fetchRefresh } from "../utils/fetchUtils";
+import { AuthContext } from "../App";
 
 export default function ProfileLayout() {
-  const { user } = useContext(AuthContext)
-  const routeParams = useParams()
+  const { user } = useContext(AuthContext);
+  const routeParams = useParams();
+  const queryClient = useQueryClient()
+
   const viewingUser = useQuery({
     queryKey: ["user", "viewing"],
     queryFn: async () => {
-      const res = await fetchRefresh(`http://127.0.0.1:8000/user/${routeParams.username}/`, {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem("access")}`,
-        },
-      })
-      return res.json()
+      const res = await fetchRefresh(
+        `http://127.0.0.1:8000/user/${routeParams.username}/`,
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("access")}`,
+          },
+        }
+      );
+      return res.json();
     },
     retry: 1,
-  })
+  });
 
-  if (viewingUser.isPending) {
-    return <p>Loading...</p>
+  const followMutation = useMutation({
+    mutationFn: async () => {
+      console.log("follow mutationFn fired");
+      return await fetch(
+        `http://127.0.0.1:8000/user/${viewingUser.data.id}/follow/`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            user_id: user.data.pk,
+            following_user_id: viewingUser.data.id,
+          }),
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("access")}`,
+            "Content-Type": "application/json",
+          },
+        }
+      )
+        .then((res) => res.json())
+        .then((data) => console.log(data))
+        .catch((err) => console.error(err));
+    },
+    onSuccess: () => {
+      console.log("follow mutation success");
+      queryClient.refetchQueries({queryKey: ["user", "viewing"]})
+    },
+  });
+
+  const unfollowMutation = useMutation({
+    mutationFn: async () => {
+      console.log("unfollow mutationFn fired");
+      return await fetch(
+        `http://127.0.0.1:8000/user/${viewingUser.data.id}/unfollow/`,
+        {
+          method: "DELETE",
+          body: JSON.stringify({
+            user_id: user.data.pk,
+            following_user_id: viewingUser.data.id,
+          }),
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("access")}`,
+            "Content-Type": "application/json",
+          },
+        }
+      )
+        .then((res) => res.json())
+        .then((data) => console.log(data))
+        .catch((err) => console.error(err));
+    },
+    onSuccess: () => {
+      console.log("unfollow mutation success");
+      queryClient.refetchQueries({queryKey: ["user", "viewing"]})
+    },
+  });
+
+  function handleFollow() {
+    console.log(`handle follow user: ${viewingUser.data.username}`);
+    followMutation.mutate();
   }
 
-  // if (!user.data) {
-  //   console.log('redirect to login')
-  //   return <Navigate to="/login" replace={true} />
-  // }
+  function handleUnfollow() {
+    console.log(`handle unfollow user: ${viewingUser.data.username}`);
+    unfollowMutation.mutate();
+  }
+
+  if (viewingUser.isPending) {
+    return <p>Loading...</p>;
+  }
 
   return (
     <>
       <h2>Profile Layout</h2>
       <p>profile layout viewing user: {JSON.stringify(viewingUser)}</p>
+      {user.data?.pk !== viewingUser.data?.id && (
+        <>
+          <p>You are {viewingUser.data?.following_user ? "" : "not "}following this user</p>
+          <button type="button" onClick={viewingUser.data?.following_user ? handleUnfollow : handleFollow}>
+            {viewingUser.data?.following_user ? "Unfollow" : "Follow"}
+          </button>
+        </>
+      )}
       <Outlet />
     </>
-  )
+  );
 }


### PR DESCRIPTION
## Changes

### Major Changes
Add mutations for following/unfollowing a user to the `ProfileLayout.tsx` route and incorporate logic to render the correct button that fires the correct mutation depending on whether the current logged in user is following the user currently being viewed.

### Bug Fixes / Minor Changes
- Miscellaneous Prettier formatting changes

## Issues
N/A

## Why
Follow/unfollow functionality should be on page where user info is, so in the `ProfileLayout.tsx` route is most appropriate.

## How
Mutation functions are the same that are in `User.tsx`, and `onSuccess` for each mutation (follow or unfollow) triggers a refetch of the viewed user query so that the updated state of whether the current user is following the user currently being viewed is up-to-date.

## Notes
Originally attempted with React's `useState` hook to track whether the current logged in user is following the currently viewed user, but there were issues in getting this state value to stay up-to-date, even with a refetch after firing the follow/unfollow mutations. This also caused some issues where a refresh of the page would cause a disparity between the React state and the value in the database.

It ended up being easiest to have the logic of the follow/unfollow button tied directly to the currently viewed user's query data, so no state required.
