### PR TITLE
Create modal dialog for limited create post component on all pages

### DIFF
--- a/frontend/src/components/CreatePostLimited.tsx
+++ b/frontend/src/components/CreatePostLimited.tsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { useMutation } from "@tanstack/react-query";
 import Fuse from "fuse.js";
 
-export default function CreatePostLimited() {
+export default function CreatePostLimited({ onSuccessSetDialogOpen }) {
   const {
     register: registerWord,
     getValues: getValuesWord,
@@ -44,6 +44,7 @@ export default function CreatePostLimited() {
       console.log("create post mutation success");
       resetFieldWord("word")
       resetFieldPost("content")
+      onSuccessSetDialogOpen(false)
     },
   });
 

--- a/frontend/src/components/CreatePostLimited.tsx
+++ b/frontend/src/components/CreatePostLimited.tsx
@@ -134,6 +134,7 @@ export default function CreatePostLimited() {
               message: "Word is required",
             },
             validate: {
+              isUnused: v => !usedWords.includes(v) || "Word is already used",
               isAvailable: v => availableWords.includes(v) || "Word is not available",
             },
           })}

--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -3,8 +3,6 @@ import { Navigate } from "react-router-dom";
 import { AuthContext } from "../App";
 import AllFeed from "../components/AllFeed";
 import AllComments from "../components/AllComments";
-import CreatePost from "../components/CreatePost";
-import CreatePostLimited from "../components/CreatePostLimited";
 
 export default function Home() {
   const { user } = useContext(AuthContext)
@@ -27,8 +25,6 @@ export default function Home() {
     <>
       <title>Cannoli | Home</title>
       <h2>Home</h2>
-      <CreatePost />
-      <CreatePostLimited />
       <h3>Feed</h3>
       <AllFeed />
       <AllComments />

--- a/frontend/src/routes/Root.module.css
+++ b/frontend/src/routes/Root.module.css
@@ -1,0 +1,20 @@
+.dialogOverlay {
+  background-color: black;
+  opacity: 0.4;
+  position: fixed;
+  inset: 0;
+}
+
+.dialogContent {
+  border: 1px solid black;
+  background-color: white;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.dialogTopRow {
+    display: flex;
+    justify-content: space-between;
+}

--- a/frontend/src/routes/Root.tsx
+++ b/frontend/src/routes/Root.tsx
@@ -1,11 +1,16 @@
 import { Outlet } from "react-router-dom";
-import { useContext } from "react";
+import { useState, useContext } from "react";
 import { AuthContext } from "../App";
+import * as Dialog from "@radix-ui/react-dialog";
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import Nav from "../components/Nav";
+import CreatePostLimited from "../components/CreatePostLimited";
 import LogoutButton from "../components/LogoutButton";
+import styles from "./Root.module.css";
 
 export default function Root() {
-  const { user } = useContext(AuthContext)
+  const { user } = useContext(AuthContext);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   return (
     <>
@@ -18,6 +23,27 @@ export default function Root() {
         )}
       </header>
       <main>
+        <Dialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
+          <Dialog.Trigger asChild>
+            <button type="button">Create Post</button>
+          </Dialog.Trigger>
+          <Dialog.Portal>
+            <Dialog.Overlay className={styles.dialogOverlay}/>
+            <Dialog.Content className={styles.dialogContent}>
+              <div className={styles.dialogTopRow}>
+                <Dialog.Title>Create Post</Dialog.Title>
+              <Dialog.Close asChild>
+                <button type="button">Close</button>
+              </Dialog.Close>
+              </div>
+              <Dialog.Description>Accessible description</Dialog.Description>
+              <CreatePostLimited onSuccessSetDialogOpen={setDialogOpen}/>
+              <Dialog.Close asChild>
+                <button type="button">Cancel</button>
+              </Dialog.Close>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
         <Outlet />
       </main>
       <footer>
@@ -26,5 +52,4 @@ export default function Root() {
       </footer>
     </>
   );
-  
 }


### PR DESCRIPTION
## Changes

### Major Changes
Removes create post components from the Home route and move to Root so that it is available on all pages alongside nav links. Wraps the create post component in a Radix Ui dialog/modal and applies a basic layout vis CSS modules.

### Bug Fixes / Minor Changes
N/A

## Issues
N/A

## Why
Similar to Twitter/X, creating a post is available on many areas of the website alongside navigation, so this change just emulates that.

## How
N/A

## Notes
N/A
