### PR TITLE
Add Tooltips

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,8 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.52.1",
         "react-icons": "^5.2.1",
-        "react-router-dom": "^6.25.1"
+        "react-router-dom": "^6.25.1",
+        "react-tooltip": "^5.28.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -916,6 +917,31 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+      "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.7"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+      "integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.7"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+      "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==",
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -2358,6 +2384,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -3819,6 +3851,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-tooltip": {
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.28.0.tgz",
+      "integrity": "sha512-R5cO3JPPXk6FRbBHMO0rI9nkUG/JKfalBSQfZedZYzmqaZQgq7GLzF8vcCWx6IhUCKg0yPqJhXIzmIO5ff15xg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/resolve-from": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.52.1",
     "react-icons": "^5.2.1",
-    "react-router-dom": "^6.25.1"
+    "react-router-dom": "^6.25.1",
+    "react-tooltip": "^5.28.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/frontend/src/components/CreatePostLimited.module.css
+++ b/frontend/src/components/CreatePostLimited.module.css
@@ -70,6 +70,10 @@
     min-height: 1.5rem;
 }
 
+.searchResultPlaceholder {
+    color: #8f8f8f;
+}
+
 .addWordButtonRow {
     display: flex;
     width: 100%;

--- a/frontend/src/components/CreatePostLimited.tsx
+++ b/frontend/src/components/CreatePostLimited.tsx
@@ -5,6 +5,7 @@ import * as Form from '@radix-ui/react-form';
 import * as ScrollArea from "@radix-ui/react-scroll-area";
 import Fuse from "fuse.js";
 import { RiInformationLine, RiCheckFill, RiCloseLine } from "react-icons/ri";
+import { Tooltip } from 'react-tooltip'
 import styles from "./CreatePostLimited.module.css";
 
 export default function CreatePostLimited({ onSuccessSetDialogOpen }) {
@@ -169,14 +170,24 @@ export default function CreatePostLimited({ onSuccessSetDialogOpen }) {
             <Form.Label className={styles.addWordLabel}>
               <div className={styles.addWordLabelLeft}>
                 <h3>Add Word</h3>
-                <RiInformationLine />
+                <RiInformationLine
+                  data-tooltip-id="add-word-tooltip"
+                />
+                <Tooltip id="add-word-tooltip" style={{ zIndex: 99 }}>
+                  <div>
+                    <p>Type a word here to add it to the post.</p>
+                    <p>Only available words can be added.</p>
+                    <p>The check mark indicates a valid word.</p>
+                  </div>
+                </Tooltip>
               </div>
-              {errorsWord.word ? <></> : <RiCheckFill />}
+              {typedWord === "" || errorsWord.word ? <></> : <RiCheckFill />}
             </Form.Label>
             <Form.Control asChild>
               <input
                 type="text"
                 id="word"
+                placeholder="Type word here to add"
                 {...registerWord("word", {
                   required: {
                     value: true,
@@ -194,20 +205,36 @@ export default function CreatePostLimited({ onSuccessSetDialogOpen }) {
             </Form.Control>
           </Form.Field>
           <div className={styles.addWordButtonRow}>
-            <Form.Submit className={styles.addWordButton}>Add Word</Form.Submit>
+            <Form.Submit className={styles.addWordButton} data-tooltip-id="add-word-button-tooltip" data-tooltip-delay-show={1000}>Add Word</Form.Submit>
+            <Tooltip id="add-word-button-tooltip" style={{ zIndex: 99 }}>
+              <p>Add word to post if available/valid</p>
+            </Tooltip>
           </div>
         </Form.Root>
         <div className={styles.searchResults}>
-          {searchResults.map((result, index) => {
-            return <p key={index}>{result}</p>;
-          })}
+          {typedWord !== "" ? (
+            searchResults.map((result, index) => {
+              return <p key={index}>{result}</p>;
+            })
+          ) : (
+            <p className={styles.searchResultPlaceholder}>Begin typing for suggestions</p>
+          )}
         </div>
         <Form.Root onSubmit={handleSubmitPost(handleSendPost)}  className={styles.formRootContent}>
           <Form.Field name="content">
             <div className={styles.contentTopRow}>
               <Form.Label className={styles.contentLabel}>
-                <h3>Content</h3>
-                <RiInformationLine />
+                <h3>Post Content</h3>
+                <RiInformationLine
+                  data-tooltip-id="content-tooltip"
+                />
+                <Tooltip id="content-tooltip" style={{ zIndex: 99 }}>
+                  <div>
+                    <p>Added words appear here.</p>
+                    <p>Clear all words or delete words one by one.</p>
+                    <p>Click on any word to add it to the post.</p>
+                  </div>
+                </Tooltip>
               </Form.Label>
               <p>{postLength}/256</p>
             </div>
@@ -216,6 +243,7 @@ export default function CreatePostLimited({ onSuccessSetDialogOpen }) {
                 id="content"
                 readOnly
                 defaultValue=""
+                placeholder="Added words will appear here. Max of 256 characters."
                 {...registerPost("content", {
                   required: {
                     value: true,
@@ -234,13 +262,22 @@ export default function CreatePostLimited({ onSuccessSetDialogOpen }) {
             </Form.Message>
           </Form.Field>
           <div className={styles.contentButtonRow}>
-            <button type="button" onClick={handleClearPost} className={styles.clearButton}>
+            <button type="button" onClick={handleClearPost} className={styles.clearButton} data-tooltip-id="clear-tooltip" data-tooltip-delay-show={1000}>
               Clear
             </button>
-            <button type="button" onClick={handleDeleteWord} className={styles.deleteWordButton}>
+            <Tooltip id="clear-tooltip" style={{ zIndex: 99 }}>
+              <p>Clear all words</p>
+            </Tooltip>
+            <button type="button" onClick={handleDeleteWord} className={styles.deleteWordButton} data-tooltip-id="delete-tooltip" data-tooltip-delay-show={1000}>
               Delete Word
             </button>
-            <Form.Submit className={styles.postButton}>Post</Form.Submit>
+            <Tooltip id="delete-tooltip" style={{ zIndex: 99 }}>
+              <p>Delete last entered word</p>
+            </Tooltip>
+            <Form.Submit className={styles.postButton} data-tooltip-id="post-tooltip" data-tooltip-delay-show={1000}>Post</Form.Submit>
+            <Tooltip id="post-tooltip" style={{ zIndex: 99 }}>
+              <p>Submit post with the above content</p>
+            </Tooltip>
           </div>
         </Form.Root>
         {errorsPost.content && <p>{errorsPost.content.message} X</p>}
@@ -248,7 +285,16 @@ export default function CreatePostLimited({ onSuccessSetDialogOpen }) {
       <div className={styles.createPostLimitedRight}>
         <div className={styles.wordsLabel}>
           <h3>Words</h3>
-          <RiInformationLine />
+          <RiInformationLine
+            data-tooltip-id="words-tooltip"
+          />
+          <Tooltip id="words-tooltip" style={{ zIndex: 99 }}>
+            <div>
+              <p>List of available words.</p>
+              <p>Scroll to browse.</p>
+              <p>Click on any word to add it to the post.</p>
+            </div>
+          </Tooltip>
         </div>
         <ScrollArea.Root className={styles.scrollAreaRoot}>
           <ScrollArea.Viewport className={styles.scrollAreaViewport}>

--- a/frontend/src/components/CreatePostLimited.tsx
+++ b/frontend/src/components/CreatePostLimited.tsx
@@ -4,7 +4,7 @@ import { useMutation } from "@tanstack/react-query";
 import * as Form from '@radix-ui/react-form';
 import * as ScrollArea from "@radix-ui/react-scroll-area";
 import Fuse from "fuse.js";
-import { RiInformationLine, RiCheckFill, RiCloseLine } from "react-icons/ri";
+import { RiInformationLine, RiCheckFill } from "react-icons/ri";
 import { Tooltip } from 'react-tooltip'
 import styles from "./CreatePostLimited.module.css";
 

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -5,6 +5,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { RxHome, RxPerson } from "react-icons/rx";
 import { RiPencilFill, RiMoreFill, RiCloseFill } from "react-icons/ri";
+import { Tooltip } from 'react-tooltip'
 import { AuthContext } from "../App";
 import CreatePostLimited from "./CreatePostLimited";
 import LogoutButton from "./LogoutButton";
@@ -100,7 +101,10 @@ export default function NavBar() {
               <Dialog.Title>Create Post</Dialog.Title>
               <Dialog.Close asChild>
                 <button type="button" className={styles.createdLimitedPostCloseButton}>
-                  <RiCloseFill />
+                  <RiCloseFill data-tooltip-id="close-tooltip" data-tooltip-delay-show={1000}/>
+                  <Tooltip id="close-tooltip" style={{ zIndex: 99 }}>
+                    <p>Close</p>
+                  </Tooltip>
                 </button>
               </Dialog.Close>
             </div>

--- a/frontend/src/components/Post.tsx
+++ b/frontend/src/components/Post.tsx
@@ -9,6 +9,7 @@ import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { RiHeart3Line, RiHeart3Fill, RiChat3Line, RiCloseFill } from "react-icons/ri";
 import { IconContext } from "react-icons";
+import { Tooltip } from "react-tooltip";
 import styles from "./Post.module.css";
 
 dayjs.extend(relativeTime);
@@ -185,13 +186,19 @@ export default function Post({ post }) {
                   type="button"
                   onClick={handlePostUnlike}
                   className={styles.likeUnlikeButton}
+                  data-tooltip-id="unlike-tooltip"
+                  data-tooltip-delay-show={1000}
                 >
                   <IconContext.Provider
                     value={{ className: styles.unlikeIcon }}
                   >
                     <RiHeart3Fill />
+                    
                   </IconContext.Provider>
                 </button>
+                <Tooltip id="unlike-tooltip" style={{ zIndex: 99 }}>
+                  <p>Unlike</p>
+                </Tooltip>
                 {likeCount > 0 && (
                   <span className={styles.liked}>{likeCount}</span>
                 )}
@@ -202,11 +209,16 @@ export default function Post({ post }) {
                   type="button"
                   onClick={handlePostLike}
                   className={styles.likeUnlikeButton}
+                  data-tooltip-id="like-tooltip"
+                  data-tooltip-delay-show={1000}
                 >
                   <IconContext.Provider value={{ className: styles.likeIcon }}>
                     <RiHeart3Line />
                   </IconContext.Provider>
                 </button>
+                <Tooltip id="like-tooltip" style={{ zIndex: 99 }}>
+                  <p>Like</p>
+                </Tooltip>
                 {likeCount > 0 && <span>{likeCount}</span>}
               </div>
             )}
@@ -215,12 +227,17 @@ export default function Post({ post }) {
                 type="button"
                 className={styles.commentButton}
                 onClick={handleOpenCommentDialog}
+                data-tooltip-id="reply-tooltip"
+                data-tooltip-delay-show={1000}
               >
                 <IconContext.Provider value={{ className: styles.commentIcon }}>
                   <RiChat3Line />
                 </IconContext.Provider>
               </button>
             </Dialog.Trigger>
+            <Tooltip id="reply-tooltip" style={{ zIndex: 99 }}>
+              <p>Reply</p>
+            </Tooltip>
           </div>
           <Dialog.Portal>
             <Dialog.Overlay className={styles.dialogOverlay} />


### PR DESCRIPTION
## Changes

### Major Changes
Install react-tooltip and include tooltips for post like/unlike/reply and create limited post modal dialog information and buttons.

### Bug Fixes / Minor Changes
N/A

## Issues
N/A

## Why
Accessibility.

## How
Elements given unique react-tooltip `data-tooltip-id` attribute, which is then referenced in a `Tooltip` component. Each component contains child elements providing the tooltip content.

## Notes
Setting `zIndex` manually seemed to be required to avoid tooltip from appearing beneath other elements. Perhaps it's due to where the tooltip is nested in the DOM.
