### PR TITLE
Set bottom nav height and icon sizes

### DIFF
--- a/frontend/src/components/NavBottom.module.css
+++ b/frontend/src/components/NavBottom.module.css
@@ -3,11 +3,13 @@
 .navBottom{
     display: grid;
     grid-template-columns: repeat(4, 1fr);
+    align-items: center;
     padding: 0.5rem;
     background-color: var(--color-bg);
     border-top: 1px solid var(--color-bg-hover);
     width: 100%;
     gap: 0.5rem;
+    height: 120px;
 }
 
 .nav {
@@ -54,10 +56,14 @@
 
 .navLink,
 .navButton {
-    
     border-radius: 50%;
 }
 
+.navLink svg,
+.navButton svg {
+    height: 24px;
+    width: 24px;
+}
 .me {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## Changes

### Major Changes
Set fixed height for bottom nav bar as well as icons in the nav links/buttons.

### Bug Fixes / Minor Changes
N/A

## Issues
N/A

## Why
They were changing size unnecessarily during responsive updates to window resizing.

## How
N/A

## Notes
N/A
